### PR TITLE
Extrai uma função ou método para evitar repetição de código

### DIFF
--- a/.settings/.project
+++ b/.settings/.project
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>.settings</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+	</buildSpec>
+	<natures>
+	</natures>
+</projectDescription>

--- a/src/br/edu/insper/desagil/alfandega/Alfandega.java
+++ b/src/br/edu/insper/desagil/alfandega/Alfandega.java
@@ -6,6 +6,7 @@ import java.util.List;
 public class Alfandega {
 	private List<Item> itens;
 	private List<ItemTarifado> itensTarifados;
+	private boolean devido;
 
 	public Alfandega() {
 		this.itens = new ArrayList<>();
@@ -19,28 +20,25 @@ public class Alfandega {
 	public void declara(ItemTarifado itemTarifado) {
 		this.itensTarifados.add(itemTarifado);
 	}
-
-	public double getTotalDeclarado() {
+	
+	public double getTotal(boolean devido) {
 		double total = 0.0;
 		for (Item item : this.itens) {
-			total += item.getRate() * item.getValor();
+			if (devido) {
+				total += item.getRate() * item.getValor() * 0.01;
+			}
+			else {
+				total += item.getRate() * item.getValor();
+			}
 		}
 		for (ItemTarifado itemTarifado : this.itensTarifados) {
-			total += itemTarifado.getRate() * itemTarifado.getValor();
+			if (devido) {
+				total += itemTarifado.getRate() * itemTarifado.getValor() * itemTarifado.getTarifa();
+			}
+			else {
+				total += itemTarifado.getRate() * itemTarifado.getValor();
+			}
 		}
 		return total;
-	}
-
-	public double getTotalDevido() {
-		double total = 0.0;
-		for (Item item : this.itens) {
-			// Mesmo em itens sem tarifa, a alfândega cobra
-			// uma taxa de 1% Por quê? Porque eles podem.
-			total += item.getRate() * item.getValor() * 0.01;
-		}
-		for (ItemTarifado itemTarifado : this.itensTarifados) {
-			total += itemTarifado.getRate() * itemTarifado.getValor() * itemTarifado.getTarifa();
-		}
-		return total;
-	}
+}
 }

--- a/test/br/edu/insper/desagil/alfandega/AlfandegaTest.java
+++ b/test/br/edu/insper/desagil/alfandega/AlfandegaTest.java
@@ -19,111 +19,111 @@ class AlfandegaTest {
 	void testA() {
 		alfandega.declara(new Item("a", 25.0, 5.12));
 		alfandega.declara(new Item("b", 50.0, 6.19));
-		assertEquals(437.5, alfandega.getTotalDeclarado(), DELTA);
-		assertEquals(4.38, alfandega.getTotalDevido(), DELTA);
+		assertEquals(437.5, alfandega.getTotal(false), DELTA);
+		assertEquals(4.38, alfandega.getTotal(true), DELTA);
 	}
 
 	@Test
 	void testB() {
 		alfandega.declara(new Item("a", 50.0, 5.12));
 		alfandega.declara(new Item("b", 25.0, 6.19));
-		assertEquals(410.75, alfandega.getTotalDeclarado(), DELTA);
-		assertEquals(4.11, alfandega.getTotalDevido(), DELTA);
+		assertEquals(410.75, alfandega.getTotal(false), DELTA);
+		assertEquals(4.11, alfandega.getTotal(true), DELTA);
 	}
 
 	@Test
 	void testC() {
 		alfandega.declara(new Item("a", 25.0, 5.12));
 		alfandega.declara(new ItemTarifado("b", 50.0, 6.19, 0.6));
-		assertEquals(437.5, alfandega.getTotalDeclarado(), DELTA);
-		assertEquals(186.98, alfandega.getTotalDevido(), DELTA);
+		assertEquals(437.5, alfandega.getTotal(false), DELTA);
+		assertEquals(186.98, alfandega.getTotal(true), DELTA);
 	}
 
 	@Test
 	void testD() {
 		alfandega.declara(new Item("a", 50.0, 5.12));
 		alfandega.declara(new ItemTarifado("b", 25.0, 6.19, 0.6));
-		assertEquals(410.75, alfandega.getTotalDeclarado(), DELTA);
-		assertEquals(95.41, alfandega.getTotalDevido(), DELTA);
+		assertEquals(410.75, alfandega.getTotal(false), DELTA);
+		assertEquals(95.41, alfandega.getTotal(true), DELTA);
 	}
 
 	@Test
 	void testE() {
 		alfandega.declara(new ItemTarifado("a", 25.0, 5.12, 0.6));
 		alfandega.declara(new Item("b", 50.0, 6.19));
-		assertEquals(437.5, alfandega.getTotalDeclarado(), DELTA);
-		assertEquals(79.9, alfandega.getTotalDevido(), DELTA);
+		assertEquals(437.5, alfandega.getTotal(false), DELTA);
+		assertEquals(79.9, alfandega.getTotal(true), DELTA);
 	}
 
 	@Test
 	void testF() {
 		alfandega.declara(new ItemTarifado("a", 50.0, 5.12, 0.6));
 		alfandega.declara(new Item("b", 25.0, 6.19));
-		assertEquals(410.75, alfandega.getTotalDeclarado(), DELTA);
-		assertEquals(155.15, alfandega.getTotalDevido(), DELTA);
+		assertEquals(410.75, alfandega.getTotal(false), DELTA);
+		assertEquals(155.15, alfandega.getTotal(true), DELTA);
 	}
 
 	@Test
 	void testG() {
 		alfandega.declara(new ItemTarifado("a", 25.0, 5.12, 0.6));
 		alfandega.declara(new ItemTarifado("b", 50.0, 6.19, 0.6));
-		assertEquals(437.5, alfandega.getTotalDeclarado(), DELTA);
-		assertEquals(262.5, alfandega.getTotalDevido(), DELTA);
+		assertEquals(437.5, alfandega.getTotal(false), DELTA);
+		assertEquals(262.5, alfandega.getTotal(true), DELTA);
 	}
 
 	@Test
 	void testH() {
 		alfandega.declara(new ItemTarifado("a", 50.0, 5.12, 0.6));
 		alfandega.declara(new ItemTarifado("b", 25.0, 6.19, 0.6));
-		assertEquals(410.75, alfandega.getTotalDeclarado(), DELTA);
-		assertEquals(246.45, alfandega.getTotalDevido(), DELTA);
+		assertEquals(410.75, alfandega.getTotal(false), DELTA);
+		assertEquals(246.45, alfandega.getTotal(true), DELTA);
 	}
 
 	@Test
 	void testI() {
 		alfandega.declara(new ItemTarifado("a", 25.0, 5.12, 0.8));
 		alfandega.declara(new ItemTarifado("b", 50.0, 6.19, 0.8));
-		assertEquals(437.5, alfandega.getTotalDeclarado(), DELTA);
-		assertEquals(350.0, alfandega.getTotalDevido(), DELTA);
+		assertEquals(437.5, alfandega.getTotal(false), DELTA);
+		assertEquals(350.0, alfandega.getTotal(true), DELTA);
 	}
 
 	@Test
 	void testJ() {
 		alfandega.declara(new ItemTarifado("a", 50.0, 5.12, 0.8));
 		alfandega.declara(new ItemTarifado("b", 25.0, 6.19, 0.8));
-		assertEquals(410.75, alfandega.getTotalDeclarado(), DELTA);
-		assertEquals(328.6, alfandega.getTotalDevido(), DELTA);
+		assertEquals(410.75, alfandega.getTotal(false), DELTA);
+		assertEquals(328.6, alfandega.getTotal(true), DELTA);
 	}
 
 	@Test
 	void testK() {
 		alfandega.declara(new ItemTarifado("a", 25.0, 5.12, 0.6));
 		alfandega.declara(new ItemTarifado("b", 50.0, 6.19, 0.8));
-		assertEquals(437.5, alfandega.getTotalDeclarado(), DELTA);
-		assertEquals(324.4, alfandega.getTotalDevido(), DELTA);
+		assertEquals(437.5, alfandega.getTotal(false), DELTA);
+		assertEquals(324.4, alfandega.getTotal(true), DELTA);
 	}
 
 	@Test
 	void testL() {
 		alfandega.declara(new ItemTarifado("a", 50.0, 5.12, 0.6));
 		alfandega.declara(new ItemTarifado("b", 25.0, 6.19, 0.8));
-		assertEquals(410.75, alfandega.getTotalDeclarado(), DELTA);
-		assertEquals(277.4, alfandega.getTotalDevido(), DELTA);
+		assertEquals(410.75, alfandega.getTotal(false), DELTA);
+		assertEquals(277.4, alfandega.getTotal(true), DELTA);
 	}
 
 	@Test
 	void testM() {
 		alfandega.declara(new ItemTarifado("a", 25.0, 5.12, 0.8));
 		alfandega.declara(new ItemTarifado("b", 50.0, 6.19, 0.6));
-		assertEquals(437.5, alfandega.getTotalDeclarado(), DELTA);
-		assertEquals(288.1, alfandega.getTotalDevido(), DELTA);
+		assertEquals(437.5, alfandega.getTotal(false), DELTA);
+		assertEquals(288.1, alfandega.getTotal(true), DELTA);
 	}
 
 	@Test
 	void testN() {
 		alfandega.declara(new ItemTarifado("a", 50.0, 5.12, 0.8));
 		alfandega.declara(new ItemTarifado("b", 25.0, 6.19, 0.6));
-		assertEquals(410.75, alfandega.getTotalDeclarado(), DELTA);
-		assertEquals(297.65, alfandega.getTotalDevido(), DELTA);
+		assertEquals(410.75, alfandega.getTotal(false), DELTA);
+		assertEquals(297.65, alfandega.getTotal(true), DELTA);
 	}
 }


### PR DESCRIPTION
Foi identificada a oportunidade de extrair as funções getTotalDeclarado e getTotalDevido, substituindo-as por um método apenas: getTotal. O argumento booleano _devido_ é passado na função para definir qual total deve ser retornado ao final (declarado ou devido). Os testes automáticos também foram refatorados para atender às alterações no código principal. 

Por se tratar de uma alteração que visa evitar a repetição de código, aproveitando um trecho em comum entre os dois métodos antigos transformando-os em um método apenas, trata-se de uma oportunidade de melhoria na arquitetura do projeto relacionada a **abstração**. 